### PR TITLE
Add override for beam shutters question answer

### DIFF
--- a/client/hooks/use-questions.ts
+++ b/client/hooks/use-questions.ts
@@ -1,7 +1,8 @@
 import { useEffect, useState } from "react";
 import type { Question } from "@/components/quiz/QuestionCard";
 
-const PAPER_URL = "https://cdn.builder.io/o/assets%2Fcd542e002c72460ba3c19abfa4b6d1f6%2Fc23fd364ba984ce0a4b4fe408f37c95e?alt=media&token=c385f910-dd60-4cd6-9503-fb5f1481f60f&apiKey=cd542e002c72460ba3c19abfa4b6d1f6";
+const PAPER_URL =
+  "https://cdn.builder.io/o/assets%2Fcd542e002c72460ba3c19abfa4b6d1f6%2Fc23fd364ba984ce0a4b4fe408f37c95e?alt=media&token=c385f910-dd60-4cd6-9503-fb5f1481f60f&apiKey=cd542e002c72460ba3c19abfa4b6d1f6";
 
 function stripLabel(opt: string) {
   // Remove leading labels like "A:", "B:", etc.
@@ -40,7 +41,12 @@ function findOptionIndex(options: string[] | undefined, label: string): number {
 function applyOverrides(list: Question[]): Question[] {
   return list.map((q) => {
     const text = String(q.question || "").toLowerCase();
-    if (q.type === "multiple" && text.includes("shutters") && text.includes("bottom support") && text.includes("beam")) {
+    if (
+      q.type === "multiple" &&
+      text.includes("shutters") &&
+      text.includes("bottom support") &&
+      text.includes("beam")
+    ) {
       const idx = findOptionIndex(q.options, "21 days");
       if (idx >= 0) {
         return { ...q, correctAnswer: idx };
@@ -67,13 +73,21 @@ export function useQuestions() {
           if (!res.ok) throw new Error("Failed to fetch external paper");
           data = await res.json();
         } catch {
-          const resLocal = await fetch("/questions.json", { cache: "no-store" });
-          if (!resLocal.ok) throw new Error(`Failed to load questions: ${resLocal.status}`);
+          const resLocal = await fetch("/questions.json", {
+            cache: "no-store",
+          });
+          if (!resLocal.ok)
+            throw new Error(`Failed to load questions: ${resLocal.status}`);
           data = await resLocal.json();
         }
 
         let normalized: Question[];
-        if (Array.isArray(data) && data.length && data[0]?.choices && data[0]?.answer) {
+        if (
+          Array.isArray(data) &&
+          data.length &&
+          data[0]?.choices &&
+          data[0]?.answer
+        ) {
           normalized = transformPaper(data);
         } else {
           normalized = data as Question[];

--- a/client/hooks/use-questions.ts
+++ b/client/hooks/use-questions.ts
@@ -31,6 +31,25 @@ function transformPaper(paper: any[]): Question[] {
   });
 }
 
+function findOptionIndex(options: string[] | undefined, label: string): number {
+  if (!options) return -1;
+  const target = label.trim().toLowerCase();
+  return options.findIndex((o) => String(o).trim().toLowerCase() === target);
+}
+
+function applyOverrides(list: Question[]): Question[] {
+  return list.map((q) => {
+    const text = String(q.question || "").toLowerCase();
+    if (q.type === "multiple" && text.includes("shutters") && text.includes("bottom support") && text.includes("beam")) {
+      const idx = findOptionIndex(q.options, "21 days");
+      if (idx >= 0) {
+        return { ...q, correctAnswer: idx };
+      }
+    }
+    return q;
+  });
+}
+
 export function useQuestions() {
   const [questions, setQuestions] = useState<Question[] | null>(null);
   const [loading, setLoading] = useState(true);
@@ -59,6 +78,7 @@ export function useQuestions() {
         } else {
           normalized = data as Question[];
         }
+        normalized = applyOverrides(normalized);
         if (mounted) setQuestions(normalized);
       } catch (e: any) {
         if (mounted) setError(e?.message ?? "Unknown error");


### PR DESCRIPTION
## Purpose

Based on user feedback, there was an issue with a specific quiz question about beam shutters and bottom support removal timing. Users identified that the correct answer should be "21 days" for questions related to non-cantilever beam shutters and bottom support removal.

## Code changes

- Added `findOptionIndex()` helper function to locate specific answer options by label
- Added `applyOverrides()` function to programmatically correct answers for specific questions
- Implemented override logic to set correct answer to "21 days" for questions containing "shutters", "bottom support", and "beam" keywords
- Applied the override function to the question normalization pipeline
- Improved code formatting for long URL constants and conditional statementsTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/51dbdf8f820b4deb9fb449cdd259d664/vortex-lab)

👀 [Preview Link](https://51dbdf8f820b4deb9fb449cdd259d664-vortex-lab.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>51dbdf8f820b4deb9fb449cdd259d664</projectId>-->
<!--<branchName>vortex-lab</branchName>-->